### PR TITLE
feat: hide share button on mobile

### DIFF
--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -126,6 +126,10 @@ body {
   .top-links.show {
     display: flex;
   }
+
+  .top-links button.share-btn {
+    display: none;
+  }
 }
 
 .logo-section {


### PR DESCRIPTION
## Pull Request Overview

This PR implements responsive design by hiding the share button on mobile devices to improve the mobile user experience.

- Adds CSS rule to hide the share button within the mobile media query