### PR TITLE
chore(deps): pip updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@ updates:
           - "*"
 
   - package-ecosystem: "pip"
-    directory: "/"
+    directory: "/backend/"
     schedule:
       interval: "weekly"
     groups:


### PR DESCRIPTION
## Pull Request Overview

This PR updates the Dependabot configuration to change the directory for pip package ecosystem monitoring from the root directory to the backend directory.

- Updates Dependabot pip monitoring to target the `/backend/` directory instead of root