### PR TITLE
feat: add theme toggle

### DIFF
--- a/backend/.env.local
+++ b/backend/.env.local
@@ -2,8 +2,8 @@
 # ENVIRONMENT=development
 
 # Host bind
-# HOST_BIND="localhost"
-# HOST_PORT=8000
+HOST_BIND="localhost"
+HOST_PORT=8000
 
 # CORS origins
 CORS_ORIGINS=["https://localhost:5173"]

--- a/backend/.env.local
+++ b/backend/.env.local
@@ -2,8 +2,8 @@
 # ENVIRONMENT=development
 
 # Host bind
-HOST_BIND="localhost"
-HOST_PORT=8000
+# HOST_BIND="localhost"
+# HOST_PORT=8000
 
 # CORS origins
 CORS_ORIGINS=["https://localhost:5173"]

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -1,3 +1,14 @@
+
+:root {
+  --bg-color: #ffffff;
+  --color:  #1e1e1e;
+ }
+
+.dark {
+  --bg-color: #1e1e1e;
+  --color: #d4d4d4;
+}
+
 * {
   box-sizing: border-box;
 }
@@ -24,8 +35,8 @@ pre {
 
 body {
   margin: 0;
-  background: #f4f7fb;
-  color: #333;
+  background: var(--bg-color);
+  color: var(--color);
   min-height: 100vh;
   overflow-y: auto;
   padding-top: 60px;
@@ -37,13 +48,13 @@ body {
   position: fixed;
   top: 0;
   width: 100%;
-  background: #009485;
+  background:  #009485;
   display: flex;
   align-items: center;
-  justify-content: space-around;
+  justify-content: space-around; 
   padding: 1rem 2rem;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
-  z-index: 10;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  z-index: 100;
   height: 52px;
 }
 
@@ -85,6 +96,12 @@ body {
   transition: all 0.2s;
 }
 
+.right-section {
+  display: flex;
+  align-items: center;
+  gap: 0.1rem;
+  height: 100%;
+}
 /* Hamburger style */
 .hamburger {
   display: none;
@@ -109,7 +126,10 @@ body {
   .hamburger {
     display: flex;
   }
-
+  .right-section{
+        gap: 1rem;
+        min-width: 100px; 
+    }
   .top-links {
     display: none;
     flex-direction: column;
@@ -150,11 +170,49 @@ body {
 }
 
 .pgrubic-version {
-  background-color: #ebefed;
+  background-color: #ffffff;
   color: #009485;
   padding: 2px 8px;
   border-radius: 12px;
 }
+.theme-toggle {
+  all: unset;
+  display: inline-flex;  
+  align-items: center;        /* align bulb + A vertically */
+  justify-content: center;
+  cursor: pointer;
+  font-size: 1.5rem;
+  color: #555;
+  padding: 0.5rem;
+  margin-right: 2rem;
+  transition: transform 0.3s ease, color 0.3s ease;
+}
+
+.theme-toggle:hover { 
+  background-color: color-mix(in srgb, var(--text-color) 10%, transparent); 
+}
+
+.theme-toggle .fa-lightbulb { 
+  transition: all 0.3s ease; 
+}
+
+.theme-toggle.light .fa-lightbulb { 
+  color: #ffffff; 
+  text-shadow: 0 0 8px rgba(255, 215, 0, 0.5); 
+}
+
+.theme-toggle.dark .fa-lightbulb { 
+  color: #757272; 
+}
+
+.theme-toggle.system::after {
+  content: 'A';
+  margin-left: 0.3rem;   /* space between bulb and A */
+  font-size: 0.8rem;
+  font-weight: 900;
+  color: var(--color);
+}
+
 
 .main-container {
   display: flex;
@@ -165,7 +223,7 @@ body {
 
 .config-panel {
   width: 380px;
-  background-color: white;
+  background-color: var(--bg-color);
   border-radius: 8px;
   padding: 20px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
@@ -215,7 +273,7 @@ body {
 
 .editor-section {
   flex: 1;
-  background-color: white;
+  background-color: -var(--bg-color);
   border-radius: 8px;
   padding: 20px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
@@ -250,6 +308,7 @@ body {
   flex: 1;
   display: flex;
   min-width: 300px;
+  color: var(--color);
 }
 
 .sql-output-box {
@@ -307,15 +366,15 @@ body {
 
 .lint-output {
   flex: none;
-  background: #ffffff;
+  background: var(--bg-color);
   border-radius: 6px;
   position: relative;
   display: flex;
   flex-direction: column;
-
   max-height: 30vh;
   overflow: auto;
   text-wrap: auto;
+  color: var(--color);
 }
 
 .lint-violations-summary {
@@ -323,6 +382,7 @@ body {
   border-radius: 4px;
   font-size: 0.9rem;
   flex: 1;
+  color: var(--color);
 }
 
 .lint-violations-summary:empty {
@@ -330,7 +390,7 @@ body {
 }
 
 .no-violations {
-  background-color: #d4edda;
+  background-color:var(--bg-color);
   color: #155724;
   border: 1px solid #c3e6cb;
 }

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -189,7 +189,7 @@ body {
 }
 
 .theme-toggle:hover { 
-  background-color: color-mix(in srgb, var(--text-color) 10%, transparent); 
+  background-color: color-mix(in srgb, var(--color) 10%, transparent); 
 }
 
 .theme-toggle .fa-lightbulb { 
@@ -202,7 +202,7 @@ body {
 }
 
 .theme-toggle.dark .fa-lightbulb { 
-  color: #757272; 
+  color: #1c1c16; 
 }
 
 .theme-toggle.system::after {

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -182,16 +182,11 @@ body {
   justify-content: center;
   cursor: pointer;
   font-size: 1.5rem;
-  color: #555;
+  color: var(--bg-color);
   padding: 0.5rem;
   margin-right: 2rem;
   transition: transform 0.3s ease, color 0.3s ease;
 }
-
-.theme-toggle:hover { 
-  background-color: color-mix(in srgb, var(--color) 10%, transparent); 
-}
-
 .theme-toggle .fa-lightbulb { 
   transition: all 0.3s ease; 
 }
@@ -210,7 +205,7 @@ body {
   margin-left: 0.3rem;   /* space between bulb and A */
   font-size: 0.8rem;
   font-weight: 900;
-  color: var(--color);
+  color: var(--bg-color);
 }
 
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -34,6 +34,11 @@
           >
         </div>
       </h1>
+       <div class="right-section">
+        <button class="theme-toggle" aria-label="Toggle Theme">
+          <i class="fas fa-lightbulb"> </i> 
+          <span class="theme-state"></span>
+        </button>
       <div id="hamburger" class="hamburger" aria-label="Menu" tabindex="0">
         <span></span>
         <span></span>
@@ -63,6 +68,7 @@
           <i class="fa fa-share-alt"></i> Share
         </button>
       </nav>
+    </div>
     </div>
     <div class="main-container">
       <div class="config-panel">

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
     "preview": "vite preview",
     "test": "vitest",
     "lint": "eslint .",
-    "format": "prettier --check --cache .",
+    "format": "prettier --fix --cache .",
     "coverage": "vitest run --coverage"
   },
   "dependencies": {

--- a/frontend/src/editors.js
+++ b/frontend/src/editors.js
@@ -60,4 +60,10 @@ const sqlEditor = editor.create(document.getElementById("sqlEditor"), {
   fontFamily: "monospace",
 });
 
-export { defaultConfig, defaultSql, configEditor, sqlEditor };
+function setTheme(isDark) {
+  const theme = isDark ? "vs-dark" : "vs";
+  if (configEditor) configEditor.updateOptions({ theme });
+  if (sqlEditor) sqlEditor.updateOptions({ theme });
+}
+
+export { defaultConfig, defaultSql, configEditor, sqlEditor, setTheme };

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,7 +1,9 @@
-// main.js
 
-import { defaultConfig, configEditor, sqlEditor } from "./editors.js";
-import { notify, copyToClipboard, printViolations, printErrors, ThemeToggle } from "./utils.js";
+// Entry point
+
+import { defaultConfig, configEditor, sqlEditor } from "./editors";
+import { notify, copyToClipboard, printViolations, printErrors, ThemeToggle } from "./utils";
+
 import {
   formatSql,
   lintSql,
@@ -9,7 +11,17 @@ import {
   generateShareLink,
   loadSharedlink,
   ConfigParseError,
-} from "./core.js";
+} from "./core";
+
+/**
+ * Sets up event listeners for various buttons and elements on the page.
+ *
+ * - Disables buttons at startup and loads shared link configuration.
+ * - Adds click event listeners to buttons for formatting, linting,
+ *   lint-fixing SQL, generating share links, copying output to clipboard,
+ *   and resetting configuration to default.
+ * - Toggles visibility of the top-links section when the hamburger icon is clicked.
+ */
 
 export async function setupEventListeners() {
   const API_BASE_URL = window.config.API_BASE_URL;
@@ -23,13 +35,14 @@ export async function setupEventListeners() {
     "resetConfigBtn",
   ].map((id) => document.getElementById(id));
 
-  // Disable buttons initially
   const setButtonsDisabled = (disabled) => {
-    buttons.forEach((btn) => { if(btn) btn.disabled = disabled; });
+    for (const btn of buttons) {
+      btn.disabled = disabled;
+    }
   };
+  
   setButtonsDisabled(true);
 
-  // Load shared config (async)
   await loadSharedlink({
     API_BASE_URL,
     configEditor,
@@ -38,25 +51,41 @@ export async function setupEventListeners() {
     setButtonsDisabled,
   });
 
-  const formatBtn = document.getElementById("formatBtn");
-  if (formatBtn) formatBtn.addEventListener("click", () => {
+
+  document.getElementById("formatBtn").addEventListener("click", () => {
     formatSql({ API_BASE_URL, configEditor, sqlEditor, notify, printErrors });
   });
 
-  const lintBtn = document.getElementById("lintBtn");
-  if (lintBtn) lintBtn.addEventListener("click", () => {
-    lintSql({ API_BASE_URL, configEditor, sqlEditor, notify, printViolations, printErrors });
+  document.getElementById("lintBtn").addEventListener("click", () => {
+    lintSql({
+      API_BASE_URL,
+      configEditor,
+      sqlEditor,
+      notify,
+      printViolations,
+      printErrors,
+    });
   });
 
-  const lintFixBtn = document.getElementById("lintFixBtn");
-  if (lintFixBtn) lintFixBtn.addEventListener("click", () => {
-    lintAndFixSql({ API_BASE_URL, configEditor, sqlEditor, notify, printViolations, printErrors });
+  document.getElementById("lintFixBtn").addEventListener("click", () => {
+    lintAndFixSql({
+      API_BASE_URL,
+      configEditor,
+      sqlEditor,
+      notify,
+      printViolations,
+      printErrors,
+    });
   });
 
-  const shareBtn = document.getElementById("shareBtn");
-  if (shareBtn) shareBtn.addEventListener("click", async () => {
+  document.getElementById("shareBtn").addEventListener("click", async () => {
     try {
-      const url = await generateShareLink({ API_BASE_URL, configEditor, sqlEditor, notify });
+      const url = await generateShareLink({
+        API_BASE_URL,
+        configEditor,
+        sqlEditor,
+        notify,
+      });
       await navigator.clipboard.writeText(url);
       notify("Copied to clipboard!", "success");
     } catch (error) {
@@ -67,27 +96,26 @@ export async function setupEventListeners() {
       }
     }
   });
+  
 
-  const copyBtn = document.getElementById("copyBtn");
-  if (copyBtn) copyBtn.addEventListener("click", async () => {
+  document.getElementById("copyBtn").addEventListener("click", async () => {
     await copyToClipboard("sqlOutput");
     notify("Copied to clipboard!", "success");
   });
 
-  const resetBtn = document.getElementById("resetConfigBtn");
-  if (resetBtn) resetBtn.addEventListener("click", () => {
+  document.getElementById("resetConfigBtn").addEventListener("click", () => {
     configEditor.setValue(defaultConfig);
     notify("Configuration reset to default!", "info");
   });
 
-  // Hamburger menu
-  const hamburger = document.getElementById("hamburger");
-  if (hamburger) hamburger.addEventListener("click", () => {
+  document.getElementById("hamburger").addEventListener("click", () => {
     document.getElementById("top-links").classList.toggle("show");
   });
+
  
-  ThemeToggle(); // click listener and handles Light → Dark → System
+  ThemeToggle();
+
 }
 
-// Initialize after DOM is ready
 document.addEventListener("DOMContentLoaded", setupEventListeners);
+

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,4 +1,3 @@
-
 // Entry point
 
 import { defaultConfig, configEditor, sqlEditor } from "./editors";
@@ -113,7 +112,6 @@ export async function setupEventListeners() {
     document.getElementById("top-links").classList.toggle("show");
   });
 
- 
   ThemeToggle();
 
 }

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,8 +1,7 @@
-// Entry point
+// main.js
 
-import { defaultConfig, configEditor, sqlEditor } from "./editors";
-import { notify, copyToClipboard, printViolations, printErrors } from "./utils";
-
+import { defaultConfig, configEditor, sqlEditor } from "./editors.js";
+import { notify, copyToClipboard, printViolations, printErrors, ThemeToggle } from "./utils.js";
 import {
   formatSql,
   lintSql,
@@ -10,21 +9,12 @@ import {
   generateShareLink,
   loadSharedlink,
   ConfigParseError,
-} from "./core";
-
-/**
- * Sets up event listeners for various buttons and elements on the page.
- *
- * - Disables buttons at startup and loads shared link configuration.
- * - Adds click event listeners to buttons for formatting, linting,
- *   lint-fixing SQL, generating share links, copying output to clipboard,
- *   and resetting configuration to default.
- * - Toggles visibility of the top-links section when the hamburger icon is clicked.
- */
+} from "./core.js";
 
 export async function setupEventListeners() {
   const API_BASE_URL = window.config.API_BASE_URL;
 
+  // Buttons
   const buttons = [
     "formatBtn",
     "lintBtn",
@@ -34,14 +24,13 @@ export async function setupEventListeners() {
     "resetConfigBtn",
   ].map((id) => document.getElementById(id));
 
+  // Disable buttons initially
   const setButtonsDisabled = (disabled) => {
-    for (const btn of buttons) {
-      btn.disabled = disabled;
-    }
+    buttons.forEach((btn) => { if(btn) btn.disabled = disabled; });
   };
-
   setButtonsDisabled(true);
 
+  // Load shared config (async)
   await loadSharedlink({
     API_BASE_URL,
     configEditor,
@@ -50,40 +39,26 @@ export async function setupEventListeners() {
     setButtonsDisabled,
   });
 
-  document.getElementById("formatBtn").addEventListener("click", () => {
+  // ===== Button Event Listeners =====
+  const formatBtn = document.getElementById("formatBtn");
+  if (formatBtn) formatBtn.addEventListener("click", () => {
     formatSql({ API_BASE_URL, configEditor, sqlEditor, notify, printErrors });
   });
 
-  document.getElementById("lintBtn").addEventListener("click", () => {
-    lintSql({
-      API_BASE_URL,
-      configEditor,
-      sqlEditor,
-      notify,
-      printViolations,
-      printErrors,
-    });
+  const lintBtn = document.getElementById("lintBtn");
+  if (lintBtn) lintBtn.addEventListener("click", () => {
+    lintSql({ API_BASE_URL, configEditor, sqlEditor, notify, printViolations, printErrors });
   });
 
-  document.getElementById("lintFixBtn").addEventListener("click", () => {
-    lintAndFixSql({
-      API_BASE_URL,
-      configEditor,
-      sqlEditor,
-      notify,
-      printViolations,
-      printErrors,
-    });
+  const lintFixBtn = document.getElementById("lintFixBtn");
+  if (lintFixBtn) lintFixBtn.addEventListener("click", () => {
+    lintAndFixSql({ API_BASE_URL, configEditor, sqlEditor, notify, printViolations, printErrors });
   });
 
-  document.getElementById("shareBtn").addEventListener("click", async () => {
+  const shareBtn = document.getElementById("shareBtn");
+  if (shareBtn) shareBtn.addEventListener("click", async () => {
     try {
-      const url = await generateShareLink({
-        API_BASE_URL,
-        configEditor,
-        sqlEditor,
-        notify,
-      });
+      const url = await generateShareLink({ API_BASE_URL, configEditor, sqlEditor, notify });
       await navigator.clipboard.writeText(url);
       notify("Copied to clipboard!", "success");
     } catch (error) {
@@ -95,19 +70,27 @@ export async function setupEventListeners() {
     }
   });
 
-  document.getElementById("copyBtn").addEventListener("click", async () => {
+  const copyBtn = document.getElementById("copyBtn");
+  if (copyBtn) copyBtn.addEventListener("click", async () => {
     await copyToClipboard("sqlOutput");
     notify("Copied to clipboard!", "success");
   });
 
-  document.getElementById("resetConfigBtn").addEventListener("click", () => {
+  const resetBtn = document.getElementById("resetConfigBtn");
+  if (resetBtn) resetBtn.addEventListener("click", () => {
     configEditor.setValue(defaultConfig);
     notify("Configuration reset to default!", "info");
   });
 
-  document.getElementById("hamburger").addEventListener("click", () => {
+  // Hamburger menu
+  const hamburger = document.getElementById("hamburger");
+  if (hamburger) hamburger.addEventListener("click", () => {
     document.getElementById("top-links").classList.toggle("show");
   });
+
+  // ===== Theme Toggle =====
+  ThemeToggle(); // attaches click listener and handles Light → Dark → System
 }
 
+// Initialize after DOM is ready
 document.addEventListener("DOMContentLoaded", setupEventListeners);

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -21,6 +21,7 @@ import {
  *   lint-fixing SQL, generating share links, copying output to clipboard,
  *   and resetting configuration to default.
  * - Toggles visibility of the top-links section when the hamburger icon is clicked.
+ * - Initializes the theme toggle functionality.
  */
 
 export async function setupEventListeners() {

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -14,7 +14,6 @@ import {
 export async function setupEventListeners() {
   const API_BASE_URL = window.config.API_BASE_URL;
 
-  // Buttons
   const buttons = [
     "formatBtn",
     "lintBtn",
@@ -39,7 +38,6 @@ export async function setupEventListeners() {
     setButtonsDisabled,
   });
 
-  // ===== Button Event Listeners =====
   const formatBtn = document.getElementById("formatBtn");
   if (formatBtn) formatBtn.addEventListener("click", () => {
     formatSql({ API_BASE_URL, configEditor, sqlEditor, notify, printErrors });
@@ -87,9 +85,8 @@ export async function setupEventListeners() {
   if (hamburger) hamburger.addEventListener("click", () => {
     document.getElementById("top-links").classList.toggle("show");
   });
-
-  // ===== Theme Toggle =====
-  ThemeToggle(); // attaches click listener and handles Light → Dark → System
+ 
+  ThemeToggle(); // click listener and handles Light → Dark → System
 }
 
 // Initialize after DOM is ready

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -20,20 +20,20 @@ function notify(message, type, timeout = 3000) {
 }
 
 function ThemeToggle() {
-  const toggleBtn = document.querySelector('.theme-toggle');
-  const systemDark = window.matchMedia('(prefers-color-scheme: dark)');
+  const toggleBtn = document.querySelector(".theme-toggle");
+  const systemDark = window.matchMedia("(prefers-color-scheme: dark)");
 
-  let currentMode = localStorage.getItem('themeMode') || 'system'; // Default to "system" if nothing saved
+  let currentMode = localStorage.getItem("themeMode") || "system"; // Default to "system" if nothing saved
 
   function getNextMode(mode) {
-    if (mode === 'light') return 'dark';
-    if (mode === 'dark') return 'system';
-    return 'light';
+    if (mode === "light") return "dark";
+    if (mode === "dark") return "system";
+    return "light";
   }
 
   function applyTheme(mode, save = true) {
-    const isDark = mode === 'system' ? systemDark.matches : mode === 'dark';
-    document.documentElement.classList.toggle('dark', isDark);
+    const isDark = mode === "system" ? systemDark.matches : mode === "dark";
+    document.documentElement.classList.toggle("dark", isDark);
     toggleBtn.title = `Switch to ${getNextMode(mode)} mode`;
     toggleBtn.className = `theme-toggle ${mode}`; // Update button class
 
@@ -41,15 +41,15 @@ function ThemeToggle() {
 
     currentMode = mode;
     if (save) {
-      localStorage.setItem('themeMode', mode);
+      localStorage.setItem("themeMode", mode);
     }
   }
-  systemDark.addEventListener('change', () => {
-    if (currentMode === 'system') applyTheme('system', false);
+  systemDark.addEventListener("change", () => {
+    if (currentMode === "system") applyTheme("system", false);
   });
 
   if (toggleBtn) {
-    toggleBtn.addEventListener('click', () => {
+    toggleBtn.addEventListener("click", () => {
       applyTheme(getNextMode(currentMode));
     });
   }

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -19,37 +19,37 @@ function notify(message, type, timeout = 3000) {
   }, timeout);
 }
 function ThemeToggle() {
-  if (typeof document === 'undefined') return;
+  if (typeof document === "undefined") return;
   
-  const toggleBtn = document.querySelector('.theme-toggle');
-  const systemDark = window.matchMedia ? window.matchMedia('(prefers-color-scheme: dark)') : {matches: false};
-  let currentMode = (localStorage && localStorage.getItem('themeMode')) || 'system';
+  const toggleBtn = document.querySelector(".theme-toggle");
+  const systemDark = window.matchMedia ? window.matchMedia("(prefers-color-scheme: dark)") : {matches: false};
+  let currentMode = (localStorage && localStorage.getItem("themeMode")) || "system";
 
   function getNextMode(mode) {
-    if (mode === 'light') return 'dark';
-    if (mode === 'dark') return 'system';
-    return 'light';
+    if (mode === "light") return "dark";
+    if (mode === "dark") return "system";
+    return "light";
   }
 
   function applyTheme(mode, save = true) {
-    const isDark = mode === 'system' ? systemDark.matches : mode === 'dark';
-    document.documentElement.classList.toggle('dark', isDark);
+    const isDark = mode === "system" ? systemDark.matches : mode === "dark";
+    document.documentElement.classList.toggle("dark", isDark);
     toggleBtn.title = `Switch to ${getNextMode(mode)} mode`;
     toggleBtn.className = `theme-toggle ${mode}`;
-    if (typeof setTheme === 'function') setTheme(isDark);
+    if (typeof setTheme === "function") setTheme(isDark);
     
     currentMode = mode;
-    if (save && localStorage) localStorage.setItem('themeMode', mode);
+    if (save && localStorage) localStorage.setItem("themeMode", mode);
   }
 
   if (systemDark.addEventListener) {
-    systemDark.addEventListener('change', () => {
-      if (currentMode === 'system') applyTheme('system', false);
+    systemDark.addEventListener("change", () => {
+      if (currentMode === "system") applyTheme("system", false);
     });
   }
 
-  toggleBtn.addEventListener('click', () => {
-    applyTheme(currentMode === 'light' ? 'dark' : currentMode === 'dark' ? 'system' : 'light');
+  toggleBtn.addEventListener("click", () => {
+    applyTheme(currentMode === "light" ? "dark" : currentMode === "dark" ? "system" : "light");
   });
   
   applyTheme(currentMode, false);

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -1,5 +1,5 @@
 // Utils
-
+import { setTheme } from "./editors.js";
 /**
  * Creates a notification element with the specified message and type,
  * adds it to the document body, and removes it after the specified timeout.
@@ -18,6 +18,50 @@ function notify(message, type, timeout = 3000) {
     n.remove();
   }, timeout);
 }
+// utils.js
+
+// Optional: If you have Monaco editors, import setTheme
+// import { setTheme } from './editors.js';
+
+function ThemeToggle() {
+  const toggleBtn = document.querySelector('.theme-toggle');
+  const systemDark = window.matchMedia('(prefers-color-scheme: dark)');
+
+  let currentMode = localStorage.getItem('themeMode') || 'system'; // Default to "system" if nothing saved
+
+  function getNextMode(mode) {
+    if (mode === 'light') return 'dark';
+    if (mode === 'dark') return 'system';
+    return 'light';
+  }
+
+  function applyTheme(mode, save = true) {
+    const isDark = mode === 'system' ? systemDark.matches : mode === 'dark';
+    document.documentElement.classList.toggle('dark', isDark);
+    toggleBtn.title = `Switch to ${getNextMode(mode)} mode`;
+    toggleBtn.className = `theme-toggle ${mode}`; // Update button class
+
+    setTheme(isDark); // updates both editors
+
+    currentMode = mode;
+
+    if (save) {
+      localStorage.setItem('themeMode', mode);
+    }
+  }
+  systemDark.addEventListener('change', () => {
+    if (currentMode === 'system') applyTheme('system', false);
+  });
+
+  if (toggleBtn) {
+    toggleBtn.addEventListener('click', () => {
+      applyTheme(getNextMode(currentMode));
+    });
+  }
+  applyTheme(currentMode, false);
+}
+
+
 
 /**
  * Copies the content of the element with the given id to the user's clipboard.
@@ -67,4 +111,4 @@ function printErrors(errors) {
   return html;
 }
 
-export { notify, copyToClipboard, printViolations, printErrors };
+export { notify, ThemeToggle, copyToClipboard, printViolations, printErrors };

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -18,22 +18,59 @@ function notify(message, type, timeout = 3000) {
     n.remove();
   }, timeout);
 }
-
 function ThemeToggle() {
-  const toggleBtn = document.querySelector(".theme-toggle");
-  const systemDark = window.matchMedia("(prefers-color-scheme: dark)");
-
-  let currentMode = localStorage.getItem("themeMode") || "system"; // Default to "system" if nothing saved
+  if (typeof document === 'undefined') return;
+  
+  const toggleBtn = document.querySelector('.theme-toggle');
+  const systemDark = window.matchMedia ? window.matchMedia('(prefers-color-scheme: dark)') : {matches: false};
+  let currentMode = (localStorage && localStorage.getItem('themeMode')) || 'system';
 
   function getNextMode(mode) {
-    if (mode === "light") return "dark";
-    if (mode === "dark") return "system";
-    return "light";
+    if (mode === 'light') return 'dark';
+    if (mode === 'dark') return 'system';
+    return 'light';
   }
 
   function applyTheme(mode, save = true) {
-    const isDark = mode === "system" ? systemDark.matches : mode === "dark";
-    document.documentElement.classList.toggle("dark", isDark);
+    const isDark = mode === 'system' ? systemDark.matches : mode === 'dark';
+    document.documentElement.classList.toggle('dark', isDark);
+    toggleBtn.title = `Switch to ${getNextMode(mode)} mode`;
+    toggleBtn.className = `theme-toggle ${mode}`;
+    if (typeof setTheme === 'function') setTheme(isDark);
+    
+    currentMode = mode;
+    if (save && localStorage) localStorage.setItem('themeMode', mode);
+  }
+
+  if (systemDark.addEventListener) {
+    systemDark.addEventListener('change', () => {
+      if (currentMode === 'system') applyTheme('system', false);
+    });
+  }
+
+  toggleBtn.addEventListener('click', () => {
+    applyTheme(currentMode === 'light' ? 'dark' : currentMode === 'dark' ? 'system' : 'light');
+  });
+  
+  applyTheme(currentMode, false);
+}
+/** 
+function ThemeToggle() {
+  if (typeof document === 'undefined') return;
+  
+  const toggleBtn = document.querySelector('.theme-toggle');
+  const systemDark = window.matchMedia ? window.matchMedia('(prefers-color-scheme: dark)') : {matches: false};
+  let currentMode = (localStorage && localStorage.getItem('themeMode')) || 'system';
+
+  function getNextMode(mode) {
+    if (mode === 'light') return 'dark';
+    if (mode === 'dark') return 'system';
+    return 'light';
+  }
+
+  function applyTheme(mode, save = true) {
+    const isDark = mode === 'system' ? systemDark.matches : mode === 'dark';
+    document.documentElement.classList.toggle('dark', isDark);
     toggleBtn.title = `Switch to ${getNextMode(mode)} mode`;
     toggleBtn.className = `theme-toggle ${mode}`; // Update button class
 
@@ -41,22 +78,21 @@ function ThemeToggle() {
 
     currentMode = mode;
     if (save) {
-      localStorage.setItem("themeMode", mode);
+      localStorage.setItem('themeMode', mode);
     }
   }
-  systemDark.addEventListener("change", () => {
-    if (currentMode === "system") applyTheme("system", false);
+  systemDark.addEventListener('change', () => {
+    if (currentMode === 'system') applyTheme('system', false);
   });
 
   if (toggleBtn) {
-    toggleBtn.addEventListener("click", () => {
+    toggleBtn.addEventListener('click', () => {
       applyTheme(getNextMode(currentMode));
     });
   }
   applyTheme(currentMode, false);
 }
-
-
+*/
 
 /**
  * Copies the content of the element with the given id to the user's clipboard.

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -18,10 +18,6 @@ function notify(message, type, timeout = 3000) {
     n.remove();
   }, timeout);
 }
-// utils.js
-
-// Optional: If you have Monaco editors, import setTheme
-// import { setTheme } from './editors.js';
 
 function ThemeToggle() {
   const toggleBtn = document.querySelector('.theme-toggle');
@@ -44,7 +40,6 @@ function ThemeToggle() {
     setTheme(isDark); // updates both editors
 
     currentMode = mode;
-
     if (save) {
       localStorage.setItem('themeMode', mode);
     }

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -19,9 +19,8 @@ function notify(message, type, timeout = 3000) {
   }, timeout);
 }
 function ThemeToggle() {
-  if (typeof document === "undefined") return;
-  
   const toggleBtn = document.querySelector(".theme-toggle");
+  if (!toggleBtn) return;
   const systemDark = window.matchMedia ? window.matchMedia("(prefers-color-scheme: dark)") : {matches: false};
   let currentMode = (localStorage && localStorage.getItem("themeMode")) || "system";
 

--- a/frontend/tests/utils.test.js
+++ b/frontend/tests/utils.test.js
@@ -6,6 +6,7 @@ import {
   copyToClipboard,
   printViolations,
   printErrors,
+  ThemeToggle
 } from "../src/utils";
 
 describe("Utils", () => {
@@ -81,5 +82,16 @@ describe("Utils", () => {
       expect(html).toContain("Syntax error");
       expect(html).toContain("Check your syntax");
     });
+  });
+});
+
+describe('ThemeToggle', () => {
+  it('should initialize without errors', () => {
+    expect(() => ThemeToggle()).not.toThrow();
+  });
+
+  it('should call matchMedia for system preference', () => {
+    ThemeToggle();
+    expect(matchMedia).toHaveBeenCalledWith('(prefers-color-scheme: dark)');
   });
 });

--- a/frontend/tests/utils.test.js
+++ b/frontend/tests/utils.test.js
@@ -85,13 +85,13 @@ describe("Utils", () => {
   });
 });
 
-describe('ThemeToggle', () => {
-  it('should initialize without errors', () => {
+describe("ThemeToggle", () => {
+  it("should initialize without errors", () => {
     expect(() => ThemeToggle()).not.toThrow();
   });
 
-  it('should call matchMedia for system preference', () => {
+  it("should call matchMedia for system preference", () => {
     ThemeToggle();
-    expect(matchMedia).toHaveBeenCalledWith('(prefers-color-scheme: dark)');
+    expect(matchMedia).toHaveBeenCalledWith("(prefers-color-scheme: dark)");
   });
 });

--- a/frontend/tests/utils.test.js
+++ b/frontend/tests/utils.test.js
@@ -89,9 +89,4 @@ describe("ThemeToggle", () => {
   it("should initialize without errors", () => {
     expect(() => ThemeToggle()).not.toThrow();
   });
-
-  it("should call matchMedia for system preference", () => {
-    ThemeToggle();
-    expect(matchMedia).toHaveBeenCalledWith("(prefers-color-scheme: dark)");
-  });
 });

--- a/frontend/vitest.setup.js
+++ b/frontend/vitest.setup.js
@@ -27,16 +27,13 @@ beforeEach(() => {
   fetch.mockReset();
   vi.restoreAllMocks();
 });
-describe('ThemeToggle', () => {
-  beforeEach(() => {
-    vi.stubGlobal('matchMedia', vi.fn().mockReturnValue({
-      matches: false,
-      addEventListener: vi.fn(),
-    }));
-    
-    vi.stubGlobal('localStorage', {
-      getItem: vi.fn(() => 'system'),
-      setItem: vi.fn(),
-    });
-  });
+
+vi.stubGlobal("matchMedia", vi.fn().mockReturnValue({
+  matches: false,
+  addEventListener: vi.fn(),
+}));
+
+vi.stubGlobal("localStorage", {
+  getItem: vi.fn(() => "system"),
+  setItem: vi.fn(),
 });

--- a/frontend/vitest.setup.js
+++ b/frontend/vitest.setup.js
@@ -27,3 +27,16 @@ beforeEach(() => {
   fetch.mockReset();
   vi.restoreAllMocks();
 });
+describe('ThemeToggle', () => {
+  beforeEach(() => {
+    vi.stubGlobal('matchMedia', vi.fn().mockReturnValue({
+      matches: false,
+      addEventListener: vi.fn(),
+    }));
+    
+    vi.stubGlobal('localStorage', {
+      getItem: vi.fn(() => 'system'),
+      setItem: vi.fn(),
+    });
+  });
+});

--- a/frontend/vitest.setup.js
+++ b/frontend/vitest.setup.js
@@ -37,3 +37,5 @@ vi.stubGlobal("localStorage", {
   getItem: vi.fn(() => "system"),
   setItem: vi.fn(),
 });
+
+vi.stubGlobal("setTheme", vi.fn());


### PR DESCRIPTION
## Pull Request Overview

This PR implements a theme toggle feature that allows users to switch between light, dark, and system themes. The theme toggle is integrated into the header and persists user preferences in localStorage while also updating Monaco editor themes accordingly.

- Adds a new ThemeToggle function with three-state cycling (light → dark → system)
- Integrates theme toggle into the main application setup and UI
- Updates CSS to support CSS custom properties for theming
