### PR TITLE
feat: extend config from pgrubic

### DIFF
--- a/backend/app/infrastructure.py
+++ b/backend/app/infrastructure.py
@@ -9,7 +9,6 @@ import diskcache
 from config import settings
 from fastapi import HTTPException, status
 from pgrubic import core
-from pgrubic.core import errors
 
 # Initialize common infrastructure
 cache = diskcache.Cache()
@@ -17,13 +16,7 @@ cache = diskcache.Cache()
 
 def lint_source_code(*, data: models.LintSourceCode) -> models.LintResult:
     """Lint source code."""
-    try:
-        config = core.parse_config(data.config.model_dump(by_alias=True))
-    except errors.MissingConfigError as e:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Missing config: {e}",
-        ) from e
+    config = core.parse_config(data.config.model_dump(by_alias=True))
 
     config.lint.fix = data.with_fix
     linter = core.Linter(config=config, formatters=core.load_formatters)
@@ -73,13 +66,7 @@ def format_source_code(
     data: models.FormatSourceCode,
 ) -> models.FormatResult:
     """Format source code."""
-    try:
-        config = core.parse_config(data.config.model_dump(by_alias=True))
-    except errors.MissingConfigError as e:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Missing config: {e}",
-        ) from e
+    config = core.parse_config(data.config.model_dump(by_alias=True))
 
     formatter = core.Formatter(config=config, formatters=core.load_formatters)
 

--- a/backend/app/infrastructure.py
+++ b/backend/app/infrastructure.py
@@ -9,29 +9,24 @@ import diskcache
 from config import settings
 from fastapi import HTTPException, status
 from pgrubic import core
+from pgrubic.core import errors
 
 # Initialize common infrastructure
-config = core.parse_config()
 cache = diskcache.Cache()
 
 
 def lint_source_code(*, data: models.LintSourceCode) -> models.LintResult:
     """Lint source code."""
-    linter = core.Linter(config=config, formatters=core.load_formatters)
+    try:
+        config = core.parse_config(data.config.model_dump(by_alias=True))
+    except errors.MissingConfigError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Missing config: {e}",
+        ) from e
 
-    # Config overrides
-    config.lint.target_postgres_version = data.config.lint.target_postgres_version
-    config.lint.select = data.config.lint.select
-    config.lint.ignore = data.config.lint.ignore
-    config.lint.ignore_noqa = data.config.lint.ignore_noqa
     config.lint.fix = data.with_fix
-
-    config.format.comma_at_beginning = data.config.format.comma_at_beginning
-    config.format.new_line_before_semicolon = data.config.format.new_line_before_semicolon
-    config.format.remove_pg_catalog_from_functions = (
-        data.config.format.remove_pg_catalog_from_functions
-    )
-    config.format.lines_between_statements = data.config.format.lines_between_statements
+    linter = core.Linter(config=config, formatters=core.load_formatters)
 
     rules: set[type[core.BaseChecker]] = core.load_rules(config=config)
 
@@ -78,13 +73,13 @@ def format_source_code(
     data: models.FormatSourceCode,
 ) -> models.FormatResult:
     """Format source code."""
-    # Config overrides
-    config.format.comma_at_beginning = data.config.format.comma_at_beginning
-    config.format.new_line_before_semicolon = data.config.format.new_line_before_semicolon
-    config.format.remove_pg_catalog_from_functions = (
-        data.config.format.remove_pg_catalog_from_functions
-    )
-    config.format.lines_between_statements = data.config.format.lines_between_statements
+    try:
+        config = core.parse_config(data.config.model_dump(by_alias=True))
+    except errors.MissingConfigError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Missing config: {e}",
+        ) from e
 
     formatter = core.Formatter(config=config, formatters=core.load_formatters)
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -53,9 +53,9 @@ class LinterConfig(BaseConfig):
     """Linter configuration."""
 
     target_postgres_version: int = Field(alias="target-postgres-version", default=14)
-    additional_non_volatile_functions: frozenset[str] = Field(
+    additional_non_volatile_functions: list[str] = Field(
         alias="additional-non-volatile-functions",
-        default_factory=frozenset,
+        default_factory=list,
     )
     select: list[str] = Field(default_factory=list)
     ignore: list[str] = Field(default_factory=list)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -20,24 +20,65 @@ class Error(BaseModel):
 
 
 # Configurations
-class LinterConfig(BaseModel):
+class BaseConfig(BaseModel):
+    """Base configuration."""
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class Disallowed(BaseConfig):
+    """Disallowed."""
+
+    name: str
+    reason: str
+    use_instead: str = Field(alias="use-instead")
+
+
+class DisallowedSchema(Disallowed):
+    """Disallowed schema."""
+
+
+class Column(BaseConfig):
+    """Column."""
+
+    name: str
+    data_type: str = Field(alias="data-type")
+
+
+class DisallowedDataType(Disallowed):
+    """Disallowed data type."""
+
+
+class LinterConfig(BaseConfig):
     """Linter configuration."""
 
-    # We are not supporting every configuration option from pgrubic but clients
-    # should still be able to provide them.
-    model_config = ConfigDict(extra="allow")
-
     target_postgres_version: int = Field(alias="target-postgres-version", default=14)
-    select: list[str] = []
-    ignore: list[str] = []
-    fixable: list[str] = []
-    unfixable: list[str] = []
+    additional_non_volatile_functions: frozenset[str] = Field(
+        alias="additional-non-volatile-functions",
+        default_factory=frozenset,
+    )
+    select: list[str] = Field(default_factory=list)
+    ignore: list[str] = Field(default_factory=list)
+    fixable: list[str] = Field(default_factory=list)
+    unfixable: list[str] = Field(default_factory=list)
     ignore_noqa: bool = Field(alias="ignore-noqa", default=False)
-    allowed_extensions: list[str] = Field(alias="allowed-extensions", default=[])
-    allowed_languages: list[str] = Field(alias="allowed-languages", default=[])
-    disallowed_schemas: list[str] = Field(alias="disallowed-schemas", default=[])
-    disallowed_data_types: list[str] = Field(alias="disallowed-data-types", default=[])
-    required_columns: list[str] = Field(alias="required-columns", default=[])
+    allowed_extensions: list[str] = Field(
+        alias="allowed-extensions",
+        default_factory=list,
+    )
+    allowed_languages: list[str] = Field(alias="allowed-languages", default_factory=list)
+    disallowed_schemas: list[DisallowedSchema] = Field(
+        alias="disallowed-schemas",
+        default_factory=list,
+    )
+    disallowed_data_types: list[DisallowedDataType] = Field(
+        alias="disallowed-data-types",
+        default_factory=list,
+    )
+    required_columns: list[Column] = Field(
+        alias="required-columns",
+        default_factory=list,
+    )
     timestamp_column_suffix: str = Field(alias="timestamp-column-suffix", default="_at")
     date_column_suffix: str = Field(alias="date-column-suffix", default="_date")
     regex_partition: str = Field(alias="regex-partition", default="^.+$")
@@ -62,12 +103,8 @@ class LinterConfig(BaseModel):
     regex_sequence: str = Field(alias="regex-sequence", default="^.+$")
 
 
-class FormatterConfig(BaseModel):
+class FormatterConfig(BaseConfig):
     """Formatter configuration."""
-
-    # We are not supporting every configuration option from pgrubic but clients
-    # should still be able to provide them.
-    model_config = ConfigDict(extra="allow")
 
     comma_at_beginning: bool = Field(alias="comma-at-beginning", default=True)
     new_line_before_semicolon: bool = Field(
@@ -81,7 +118,7 @@ class FormatterConfig(BaseModel):
     lines_between_statements: int = Field(alias="lines-between-statements", default=1)
 
 
-class Config(BaseModel):
+class Config(BaseConfig):
     """Configuration."""
 
     lint: LinterConfig
@@ -89,7 +126,7 @@ class Config(BaseModel):
 
 
 # Request
-class Request(BaseModel):
+class Request(BaseConfig):
     """Request."""
 
     source_code: str

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,4 @@
-pgrubic==1.0.0
+pgrubic==1.1.0
 toml==0.10.2
 pydantic==2.13.4
 pydantic-settings==2.14.2

--- a/backend/tests/test_routes.py
+++ b/backend/tests/test_routes.py
@@ -7,6 +7,7 @@ from app.config import settings
 config = {
     "lint": {
         "target-postgres-version": 14,
+        "additional-non-volatile-functions": [],
         "select": [],
         "ignore": [],
         "fixable": [],


### PR DESCRIPTION
## Pull request overview

This PR updates the backend to work with an extended pgrubic configuration surface area, including upgrading the pgrubic dependency and adjusting how request-provided config is parsed and applied during lint/format operations.

**Changes:**
- Bumps `pgrubic` from `1.0.0` to `1.1.0`.
- Expands the Pydantic config schema (new config models / fields) and switches config parsing to use the request-provided config via `core.parse_config(...)`.
- Updates route tests to include the newly added config key.