### PR TITLE
feat: fetch pgrubic version from backend

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -40,7 +40,7 @@
         <span></span>
       </div>
       <nav class="top-links" id="top-links">
-        <span id="pgrubic-version" class="pgrubic-version">Loading...</span>
+        <span id="pgrubicVersion" class="pgrubic-version">Loading...</span>
 
         <a href="https://github.com/bolajiwahab/pgrubic" target="_blank"
           ><i class="fab fa-github"></i> GitHub</a

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -40,8 +40,8 @@
         <span></span>
       </div>
       <nav class="top-links" id="top-links">
-        <!-- version to be populated from the backend (js) eventually -->
-        <span id="pgrubic-version" class="pgrubic-version">v0.7.0</span>
+        <span id="pgrubic-version" class="pgrubic-version">Loading...</span>
+
         <a href="https://github.com/bolajiwahab/pgrubic" target="_blank"
           ><i class="fab fa-github"></i> GitHub</a
         >

--- a/frontend/src/core.js
+++ b/frontend/src/core.js
@@ -242,8 +242,7 @@ async function lintAndFixSql({
  * @param {Object} params.configEditor - The editor containing the pgrubic config.
  * @param {Object} params.sqlEditor - The editor containing the SQL code to lint.
  * @param {Function} params.notify - Function to display notifications.
- *
- * @returns {Promise<string>} A promise that resolves with the share link.
+ * @returns {Promise<string | null>} A promise that resolves with the share link, or null on failure.
  */
 async function generateShareLink({
   API_BASE_URL,
@@ -256,7 +255,7 @@ async function generateShareLink({
     configObject = toml.parse(configEditor.getValue());
   } catch {
     notify("Error in config", "error");
-    return;
+    return null;
   }
 
   const sqlOutputBox = document.getElementById("sqlOutputBox"),
@@ -286,13 +285,14 @@ async function generateShareLink({
     if (!response.ok) {
       lintOutput.innerHTML = "";
       notify("Operation failed!", "error");
-      return;
+      return null;
     }
 
     const data = await response.json();
     return `${window.location.origin}/${data.request_id}`;
   } catch {
     notify("Operation failed!", "error");
+    return null;
   }
 }
 

--- a/frontend/src/core.js
+++ b/frontend/src/core.js
@@ -260,31 +260,35 @@ async function generateShareLink({ API_BASE_URL, configEditor, sqlEditor, notify
     lintOutput = document.getElementById("lintOutput"),
     lintViolationsSummary = document.getElementById("lintViolationsSummary");
 
-  const response = await fetch(`${API_BASE_URL}/share`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      source_code: sqlEditor.getValue(),
-      config: configObject,
-      lint_violations_summary: lintViolationsSummary.innerHTML,
-      lint_violations_summary_class: lintViolationsSummary.className,
-      lint_output: lintOutput.innerHTML,
-      sql_output_box_style: sqlOutputBox.style.display,
-      sql_output_label: sqlOutputLabel.textContent,
-      sql_output: sqlOutput.textContent,
-    }),
-  });
+  try {
+    const response = await fetch(`${API_BASE_URL}/share`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        source_code: sqlEditor.getValue(),
+        config: configObject,
+        lint_violations_summary: lintViolationsSummary.innerHTML,
+        lint_violations_summary_class: lintViolationsSummary.className,
+        lint_output: lintOutput.innerHTML,
+        sql_output_box_style: sqlOutputBox.style.display,
+        sql_output_label: sqlOutputLabel.textContent,
+        sql_output: sqlOutput.textContent,
+      }),
+    });
 
-  if (!response.ok) {
-    lintOutput.innerHTML = "";
+    if (!response.ok) {
+      lintOutput.innerHTML = "";
+      notify("Operation failed!", "error");
+      return;
+    }
+
+    const data = await response.json();
+    return `${window.location.origin}/${data.request_id}`;
+  } catch {
     notify("Operation failed!", "error");
-    return;
   }
-
-  const data = await response.json();
-  return `${window.location.origin}/${data.request_id}`;
 }
 
 /**
@@ -300,7 +304,7 @@ async function generateShareLink({ API_BASE_URL, configEditor, sqlEditor, notify
  * @param {Object} params.configEditor - The editor containing the pgrubic config.
  * @param {Object} params.sqlEditor - The editor containing the SQL code to lint.
  * @param {Function} params.notify - Function to display notifications.
- * @param {Function} params.setButtonsDisabled - Function to set the disabled state of the buttons.
+ * @param {Function} params.setButtonsDisabled - Function to disable buttons.
  */
 async function loadSharedlink({
   API_BASE_URL,
@@ -372,8 +376,8 @@ async function loadSharedlink({
  * @param {string} params.API_BASE_URL - The base URL of the API.
  * @param {Function} params.notify - Function to display notifications.
  */
-async function loadPgrubicVersion({API_BASE_URL, notify}) {
-  const versionElement = document.getElementById("pgrubic-version");
+async function loadPgrubicVersion({API_BASE_URL}) {
+  const pgrubicVersion = document.getElementById("pgrubicVersion");
 
   try {
     const response = await fetch(`${API_BASE_URL}/pgrubic-version`, {
@@ -384,17 +388,14 @@ async function loadPgrubicVersion({API_BASE_URL, notify}) {
     });
 
     if (!response.ok) {
-      notify("Failed to load pgrubic version:", "info");
-      versionElement.textContent = "Unavailable";
+      pgrubicVersion.textContent = "Unavailable";
       return;
     }
 
-
     const { version } = await response.json();
-    versionElement.textContent = version;
+    pgrubicVersion.textContent = version;
   } catch {
-    // notify("Failed to load pgrubic version", "info");
-    versionElement.textContent = "Unavailable";
+    pgrubicVersion.textContent = "Unavailable";
     return;
   }
 }

--- a/frontend/src/core.js
+++ b/frontend/src/core.js
@@ -374,7 +374,6 @@ async function loadSharedlink({
  *
  * @param {Object} params - The function parameters.
  * @param {string} params.API_BASE_URL - The base URL of the API.
- * @param {Function} params.notify - Function to display notifications.
  */
 async function loadPgrubicVersion({API_BASE_URL}) {
   const pgrubicVersion = document.getElementById("pgrubicVersion");

--- a/frontend/src/core.js
+++ b/frontend/src/core.js
@@ -245,7 +245,12 @@ async function lintAndFixSql({
  *
  * @returns {Promise<string>} A promise that resolves with the share link.
  */
-async function generateShareLink({ API_BASE_URL, configEditor, sqlEditor, notify }) {
+async function generateShareLink({
+  API_BASE_URL,
+  configEditor,
+  sqlEditor,
+  notify,
+}) {
   let configObject;
   try {
     configObject = toml.parse(configEditor.getValue());
@@ -375,7 +380,7 @@ async function loadSharedlink({
  * @param {Object} params - The function parameters.
  * @param {string} params.API_BASE_URL - The base URL of the API.
  */
-async function loadPgrubicVersion({API_BASE_URL}) {
+async function loadPgrubicVersion({ API_BASE_URL }) {
   const pgrubicVersion = document.getElementById("pgrubicVersion");
 
   try {

--- a/frontend/src/core.js
+++ b/frontend/src/core.js
@@ -4,8 +4,6 @@ import { defaultConfig, defaultSql } from "./editors";
 
 import toml from "toml";
 
-class ConfigParseError extends Error {}
-
 /**
  * Formats the SQL code from the provided SQL editor using the configuration from the config editor.
  * Fetches the formatted SQL from the given API endpoint and updates the DOM with the results.
@@ -243,15 +241,17 @@ async function lintAndFixSql({
  * @param {string} params.API_BASE_URL - The base URL of the API.
  * @param {Object} params.configEditor - The editor containing the pgrubic config.
  * @param {Object} params.sqlEditor - The editor containing the SQL code to lint.
+ * @param {Function} params.notify - Function to display notifications.
  *
  * @returns {Promise<string>} A promise that resolves with the share link.
  */
-async function generateShareLink({ API_BASE_URL, configEditor, sqlEditor }) {
+async function generateShareLink({ API_BASE_URL, configEditor, sqlEditor, notify }) {
   let configObject;
   try {
     configObject = toml.parse(configEditor.getValue());
   } catch {
-    throw new ConfigParseError("Error in config");
+    notify("Error in config", "error");
+    return;
   }
 
   const sqlOutputBox = document.getElementById("sqlOutputBox"),
@@ -279,7 +279,8 @@ async function generateShareLink({ API_BASE_URL, configEditor, sqlEditor }) {
 
   if (!response.ok) {
     lintOutput.innerHTML = "";
-    throw new Error("Operation failed!");
+    notify("Operation failed!", "error");
+    return;
   }
 
   const data = await response.json();
@@ -362,11 +363,47 @@ async function loadSharedlink({
   }
 }
 
+/**
+ * Loads pgrubic version.
+ *
+ * Fetches the pgrubic version from the API and updates the DOM with the version.
+ *
+ * @param {Object} params - The function parameters.
+ * @param {string} params.API_BASE_URL - The base URL of the API.
+ * @param {Function} params.notify - Function to display notifications.
+ */
+async function loadPgrubicVersion({API_BASE_URL, notify}) {
+  const versionElement = document.getElementById("pgrubic-version");
+
+  try {
+    const response = await fetch(`${API_BASE_URL}/pgrubic-version`, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+
+    if (!response.ok) {
+      notify("Failed to load pgrubic version:", "info");
+      versionElement.textContent = "Unavailable";
+      return;
+    }
+
+
+    const { version } = await response.json();
+    versionElement.textContent = version;
+  } catch {
+    // notify("Failed to load pgrubic version", "info");
+    versionElement.textContent = "Unavailable";
+    return;
+  }
+}
+
 export {
   formatSql,
   lintSql,
   lintAndFixSql,
   generateShareLink,
   loadSharedlink,
-  ConfigParseError,
+  loadPgrubicVersion,
 };

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -25,7 +25,7 @@ import {
 export async function setupEventListeners() {
   const API_BASE_URL = window.config.API_BASE_URL;
 
-  await loadPgrubicVersion({ API_BASE_URL, notify });
+  loadPgrubicVersion({ API_BASE_URL });
 
   const buttons = [
     "formatBtn",
@@ -86,6 +86,11 @@ export async function setupEventListeners() {
       sqlEditor,
       notify,
     });
+
+    if (!url) {
+      return;
+    }
+
     await navigator.clipboard.writeText(url);
     notify("Copied to clipboard!", "success");
   });

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -42,6 +42,7 @@ export async function setupEventListeners() {
     }
   };
 
+  // Disable buttons at startup
   setButtonsDisabled(true);
 
   await loadSharedlink({

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -9,7 +9,7 @@ import {
   lintAndFixSql,
   generateShareLink,
   loadSharedlink,
-  ConfigParseError,
+  loadPgrubicVersion,
 } from "./core";
 
 /**
@@ -24,6 +24,8 @@ import {
 
 export async function setupEventListeners() {
   const API_BASE_URL = window.config.API_BASE_URL;
+
+  await loadPgrubicVersion({ API_BASE_URL, notify });
 
   const buttons = [
     "formatBtn",
@@ -77,22 +79,14 @@ export async function setupEventListeners() {
   });
 
   document.getElementById("shareBtn").addEventListener("click", async () => {
-    try {
-      const url = await generateShareLink({
-        API_BASE_URL,
-        configEditor,
-        sqlEditor,
-        notify,
-      });
-      await navigator.clipboard.writeText(url);
-      notify("Copied to clipboard!", "success");
-    } catch (error) {
-      if (error instanceof ConfigParseError) {
-        notify("Error in config", "error");
-      } else {
-        notify("Operation failed!", "error");
-      }
-    }
+    const url = await generateShareLink({
+      API_BASE_URL,
+      configEditor,
+      sqlEditor,
+      notify,
+    });
+    await navigator.clipboard.writeText(url);
+    notify("Copied to clipboard!", "success");
   });
 
   document.getElementById("copyBtn").addEventListener("click", async () => {

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -95,7 +95,12 @@ export async function setupEventListeners() {
       await navigator.clipboard.writeText(url);
       notify("Copied to clipboard!", "success");
     } catch (error) {
-      notify(error.message, "error");
+      const message =
+        error && typeof error.message === "string" && error.message
+          ? error.message
+          : "Failed to copy to clipboard.";
+
+      notify(message, "error");
     }
   });
 

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -91,8 +91,12 @@ export async function setupEventListeners() {
       return;
     }
 
-    await navigator.clipboard.writeText(url);
-    notify("Copied to clipboard!", "success");
+    try {
+      await navigator.clipboard.writeText(url);
+      notify("Copied to clipboard!", "success");
+    } catch (error) {
+      notify(error.message, "error");
+    }
   });
 
   document.getElementById("copyBtn").addEventListener("click", async () => {

--- a/frontend/tests/core.test.js
+++ b/frontend/tests/core.test.js
@@ -7,8 +7,8 @@ import {
   lintAndFixSql,
   generateShareLink,
   loadSharedlink,
+  loadPgrubicVersion,
 } from "../src/core";
-import { ConfigParseError } from "../src/core";
 
 import toml from "toml";
 
@@ -23,7 +23,8 @@ describe("Core Functions", () => {
     sqlOutput,
     sqlOutputLabel,
     lintOutput,
-    lintViolationsSummary;
+    lintViolationsSummary,
+    pgrubicVersion;
 
   // Mocks
   Object.defineProperty(window, "location", {
@@ -56,6 +57,8 @@ describe("Core Functions", () => {
   lintOutput.id = "lintOutput";
   lintViolationsSummary = document.createElement("div");
   lintViolationsSummary.id = "lintViolationsSummary";
+  pgrubicVersion = document.createElement("span");
+  pgrubicVersion.id = "pgrubicVersion";
   document.body.append(
     sqlOutputBox,
     sqlOutput,
@@ -435,22 +438,41 @@ describe("Core Functions", () => {
   });
 
   // generateShareLink
-  it("throws ConfigParseError if TOML parsing fails", async () => {
+  it("generateShareLink should notify error on config error", async () => {
     toml.parse.mockImplementation(() => {
       throw { line: 1, column: 1, message: "fail" };
     });
-    await expect(() =>
-      generateShareLink({ API_BASE_URL: "/api", configEditor, sqlEditor }),
-    ).rejects.toThrow(ConfigParseError);
+    await generateShareLink({
+      API_BASE_URL: "/api",
+      configEditor,
+      sqlEditor,
+      notify,
+    });
+    expect(notify).toHaveBeenCalledWith("Error in config", "error");
   });
 
   it("generateShareLink should handle fetch failure", async () => {
     fetch.mockResolvedValue({
       ok: false,
     });
-    await expect(() =>
-      generateShareLink({ API_BASE_URL: "/api", configEditor, sqlEditor }),
-    ).rejects.toThrow("Operation failed!");
+    await generateShareLink({
+      API_BASE_URL: "/api",
+      configEditor,
+      sqlEditor,
+      notify,
+    });
+    expect(notify).toHaveBeenCalledWith("Operation failed!", "error");
+  });
+
+  it("generateShareLink should handle other fetch failure", async () => {
+    fetch.mockRejectedValue(new Error("network error"));
+    await generateShareLink({
+      API_BASE_URL: "/api",
+      configEditor,
+      sqlEditor,
+      notify,
+    });
+    expect(notify).toHaveBeenCalledWith("Operation failed!", "error");
   });
 
   it("generateShareLink should generate share link on success", async () => {
@@ -463,6 +485,7 @@ describe("Core Functions", () => {
       API_BASE_URL: "/api",
       configEditor,
       sqlEditor,
+      notify,
     });
 
     expect(url).toBe(window.location.origin + "/abc123");
@@ -523,5 +546,27 @@ describe("Core Functions", () => {
       setButtonsDisabled,
     });
     expect(notify).toHaveBeenCalledWith("Operation failed!", "error");
+  });
+
+  // loadPgrubicVersion
+  it("loadPgrubicVersion should display version on success", async () => {
+    fetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ version: "1.0.0" }),
+    });
+    await loadPgrubicVersion({ API_BASE_URL: "/api" });
+    expect(pgrubicVersion.textContent).toBe("1.0.0");
+  });
+
+  it("loadPgrubicVersion should display 'Unavailable' on fetch failure", async () => {
+    fetch.mockResolvedValue({ ok: false });
+    await loadPgrubicVersion({ API_BASE_URL: "/api" });
+    expect(pgrubicVersion.textContent).toBe("Unavailable");
+  });
+
+  it("loadPgrubicVersion should display 'Unavailable' on other fetch failure", async () => {
+    fetch.mockRejectedValue(new Error("network error"));
+    await loadPgrubicVersion({ API_BASE_URL: "/api" });
+    expect(pgrubicVersion.textContent).toBe("Unavailable");
   });
 });

--- a/frontend/tests/core.test.js
+++ b/frontend/tests/core.test.js
@@ -19,6 +19,7 @@ describe("Core Functions", () => {
     printErrors,
     printViolations,
     setButtonsDisabled;
+
   let sqlOutputBox,
     sqlOutput,
     sqlOutputLabel,
@@ -65,6 +66,7 @@ describe("Core Functions", () => {
     sqlOutputLabel,
     lintOutput,
     lintViolationsSummary,
+    pgrubicVersion,
   );
 
   // formatSql

--- a/frontend/tests/main.test.js
+++ b/frontend/tests/main.test.js
@@ -86,17 +86,41 @@ describe("Main button event listeners", () => {
   });
 
   it("shareBtn writes share link to clipboard and notifies on success", async () => {
-    core.generateShareLink.mockResolvedValue("https://fake.share/link");
+    const shareLink = "https://fake.share/link";
+
+    core.generateShareLink.mockResolvedValue(shareLink);
 
     await document.getElementById("shareBtn").click();
     await Promise.resolve();
 
-    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
-      "https://fake.share/link",
-    );
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(shareLink);
     expect(utils.notify).toHaveBeenCalledWith(
       "Copied to clipboard!",
       "success",
+    );
+  });
+
+  it ("shareBtn notifies on clipboard write failure", async () => {
+    const shareLink = "https://fake.share/link";
+
+    vi.stubGlobal("navigator", {
+      clipboard: {
+        writeText: vi.fn().mockRejectedValue(
+          new DOMException("Permission denied", "NotAllowedError"),
+        ),
+      },
+    });
+
+    core.generateShareLink.mockResolvedValue(shareLink);
+
+    await document.getElementById("shareBtn").click();
+    await Promise.resolve();
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(shareLink);
+
+    expect(utils.notify).toHaveBeenCalledWith(
+      "Permission denied",
+      "error",
     );
   });
 
@@ -119,4 +143,5 @@ describe("Main button event listeners", () => {
     document.getElementById("hamburger").click();
     expect(topLinks.classList.contains("show")).toBe(false);
   });
+
 });

--- a/frontend/tests/main.test.js
+++ b/frontend/tests/main.test.js
@@ -53,7 +53,7 @@ describe("Main button event listeners", () => {
     vi.spyOn(utils, "notify").mockImplementation(() => {});
     vi.spyOn(core, "loadPgrubicVersion").mockResolvedValue();
 
-    setupEventListeners();
+    return setupEventListeners();
   });
 
   it("calls formatSql on formatBtn click", async () => {

--- a/frontend/tests/main.test.js
+++ b/frontend/tests/main.test.js
@@ -100,14 +100,16 @@ describe("Main button event listeners", () => {
     );
   });
 
-  it ("shareBtn notifies on clipboard write failure", async () => {
+  it("shareBtn notifies on clipboard write failure", async () => {
     const shareLink = "https://fake.share/link";
 
     vi.stubGlobal("navigator", {
       clipboard: {
-        writeText: vi.fn().mockRejectedValue(
-          new DOMException("Permission denied", "NotAllowedError"),
-        ),
+        writeText: vi
+          .fn()
+          .mockRejectedValue(
+            new DOMException("Permission denied", "NotAllowedError"),
+          ),
       },
     });
 
@@ -118,10 +120,7 @@ describe("Main button event listeners", () => {
 
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith(shareLink);
 
-    expect(utils.notify).toHaveBeenCalledWith(
-      "Permission denied",
-      "error",
-    );
+    expect(utils.notify).toHaveBeenCalledWith("Permission denied", "error");
   });
 
   it("resets config and notifies on resetConfigBtn click", () => {
@@ -143,5 +142,4 @@ describe("Main button event listeners", () => {
     document.getElementById("hamburger").click();
     expect(topLinks.classList.contains("show")).toBe(false);
   });
-
 });

--- a/frontend/tests/main.test.js
+++ b/frontend/tests/main.test.js
@@ -103,15 +103,9 @@ describe("Main button event listeners", () => {
   it("shareBtn notifies on clipboard write failure", async () => {
     const shareLink = "https://fake.share/link";
 
-    vi.stubGlobal("navigator", {
-      clipboard: {
-        writeText: vi
-          .fn()
-          .mockRejectedValue(
-            new DOMException("Permission denied", "NotAllowedError"),
-          ),
-      },
-    });
+    vi.spyOn(navigator.clipboard, "writeText").mockRejectedValue(
+      new DOMException("Permission denied", "NotAllowedError"),
+    );
 
     core.generateShareLink.mockResolvedValue(shareLink);
 

--- a/frontend/tests/main.test.js
+++ b/frontend/tests/main.test.js
@@ -7,24 +7,24 @@ import * as utils from "../src/utils";
 import { setupEventListeners } from "../src/main";
 import { configEditor, defaultConfig } from "../src/editors";
 
+// Mocks
+vi.mock("../src/editors", () => ({
+  configEditor: {
+    getValue: vi.fn(),
+    setValue: vi.fn(),
+  },
+
+  sqlEditor: {
+    getValue: vi.fn(),
+    setValue: vi.fn(),
+  },
+
+  defaultConfig: "",
+
+  defaultSql: "",
+}));
+
 describe("Main button event listeners", () => {
-  // Mocks
-  vi.mock("../src/editors", () => ({
-    configEditor: {
-      getValue: vi.fn(),
-      setValue: vi.fn(),
-    },
-
-    sqlEditor: {
-      getValue: vi.fn(),
-      setValue: vi.fn(),
-    },
-
-    defaultConfig: "",
-
-    defaultSql: "",
-  }));
-
   Object.assign(navigator, {
     clipboard: { writeText: vi.fn().mockResolvedValue() },
   });
@@ -99,38 +99,6 @@ describe("Main button event listeners", () => {
       "success",
     );
   });
-
-  // it("generateShareLink notifies with config error message on ConfigParseError", async () => {
-  //   const error = new core.ConfigParseError("Error in config");
-  //   core.generateShareLink.mockRejectedValue(error);
-
-  //   await document.getElementById("shareBtn").click();
-  //   await Promise.resolve();
-
-  //   expect(utils.notify).toHaveBeenCalledWith("Error in config", "error");
-  // });
-
-  // it("notifies with generic error message on unexpected error", async () => {
-  //   core.generateShareLink.mockRejectedValue(new TypeError("Network down"));
-
-  //   document.getElementById("shareBtn").click();
-  //   await Promise.resolve();
-
-  //   expect(utils.notify).toHaveBeenCalledWith("Operation failed!", "error");
-  // });
-
-  // it("notifies with generic error message on network failure", async () => {
-  //   vi.stubGlobal(
-  //     "fetch",
-  //     vi.fn().mockRejectedValue(new TypeError("Network down")),
-  //   );
-
-  //   document.getElementById("shareBtn").click();
-
-  //   await Promise.resolve();
-
-  //   expect(utils.notify).toHaveBeenCalledWith("Operation failed!", "error");
-  // });
 
   it("resets config and notifies on resetConfigBtn click", () => {
     document.getElementById("resetConfigBtn").click();

--- a/frontend/tests/main.test.js
+++ b/frontend/tests/main.test.js
@@ -51,6 +51,7 @@ describe("Main button event listeners", () => {
     vi.spyOn(core, "generateShareLink").mockResolvedValue();
     vi.spyOn(utils, "copyToClipboard").mockImplementation(() => {});
     vi.spyOn(utils, "notify").mockImplementation(() => {});
+    vi.spyOn(core, "loadPgrubicVersion").mockResolvedValue();
 
     setupEventListeners();
   });
@@ -99,24 +100,37 @@ describe("Main button event listeners", () => {
     );
   });
 
-  it("generateShareLink notifies with config error message on ConfigParseError", async () => {
-    const error = new core.ConfigParseError("Error in config");
-    core.generateShareLink.mockRejectedValue(error);
+  // it("generateShareLink notifies with config error message on ConfigParseError", async () => {
+  //   const error = new core.ConfigParseError("Error in config");
+  //   core.generateShareLink.mockRejectedValue(error);
 
-    await document.getElementById("shareBtn").click();
-    await Promise.resolve();
+  //   await document.getElementById("shareBtn").click();
+  //   await Promise.resolve();
 
-    expect(utils.notify).toHaveBeenCalledWith("Error in config", "error");
-  });
+  //   expect(utils.notify).toHaveBeenCalledWith("Error in config", "error");
+  // });
 
-  it("notifies with generic error message on unexpected error", async () => {
-    core.generateShareLink.mockRejectedValue(new Error("Network down"));
+  // it("notifies with generic error message on unexpected error", async () => {
+  //   core.generateShareLink.mockRejectedValue(new TypeError("Network down"));
 
-    await document.getElementById("shareBtn").click();
-    await Promise.resolve();
+  //   document.getElementById("shareBtn").click();
+  //   await Promise.resolve();
 
-    expect(utils.notify).toHaveBeenCalledWith("Operation failed!", "error");
-  });
+  //   expect(utils.notify).toHaveBeenCalledWith("Operation failed!", "error");
+  // });
+
+  // it("notifies with generic error message on network failure", async () => {
+  //   vi.stubGlobal(
+  //     "fetch",
+  //     vi.fn().mockRejectedValue(new TypeError("Network down")),
+  //   );
+
+  //   document.getElementById("shareBtn").click();
+
+  //   await Promise.resolve();
+
+  //   expect(utils.notify).toHaveBeenCalledWith("Operation failed!", "error");
+  // });
 
   it("resets config and notifies on resetConfigBtn click", () => {
     document.getElementById("resetConfigBtn").click();

--- a/frontend/tests/main.test.js
+++ b/frontend/tests/main.test.js
@@ -100,7 +100,7 @@ describe("Main button event listeners", () => {
     );
   });
 
-  it("shareBtn notifies on clipboard write failure", async () => {
+  it("shareBtn notifies on clipboard write failure with error message", async () => {
     const shareLink = "https://fake.share/link";
 
     vi.spyOn(navigator.clipboard, "writeText").mockRejectedValue(
@@ -115,6 +115,23 @@ describe("Main button event listeners", () => {
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith(shareLink);
 
     expect(utils.notify).toHaveBeenCalledWith("Permission denied", "error");
+  });
+
+  it("shareBtn notifies on clipboard write failure without error message", async () => {
+    const shareLink = "https://fake.share/link";
+
+    vi.spyOn(navigator.clipboard, "writeText").mockRejectedValue(
+      new DOMException("", "NotAllowedError"),
+    );
+
+    core.generateShareLink.mockResolvedValue(shareLink);
+
+    await document.getElementById("shareBtn").click();
+    await Promise.resolve();
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(shareLink);
+
+    expect(utils.notify).toHaveBeenCalledWith("Failed to copy to clipboard.", "error");
   });
 
   it("resets config and notifies on resetConfigBtn click", () => {

--- a/frontend/tests/main.test.js
+++ b/frontend/tests/main.test.js
@@ -131,7 +131,10 @@ describe("Main button event listeners", () => {
 
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith(shareLink);
 
-    expect(utils.notify).toHaveBeenCalledWith("Failed to copy to clipboard.", "error");
+    expect(utils.notify).toHaveBeenCalledWith(
+      "Failed to copy to clipboard.",
+      "error",
+    );
   });
 
   it("resets config and notifies on resetConfigBtn click", () => {

--- a/frontend/vitest.setup.js
+++ b/frontend/vitest.setup.js
@@ -1,4 +1,4 @@
-import { vi, beforeEach } from "vitest";
+import { vi, beforeEach, afterEach } from "vitest";
 
 // Mock monaco editor
 vi.mock("monaco-editor/esm/vs/editor/editor.api", () => ({
@@ -26,4 +26,8 @@ globalThis.fetch = vi.fn();
 beforeEach(() => {
   fetch.mockReset();
   vi.resetAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
 });


### PR DESCRIPTION
## Pull request overview

This PR adds a frontend-visible “pgrubic version” that is fetched from the backend at runtime, and refactors share-link error handling so the core layer is responsible for user notifications rather than throwing errors back to the UI.

**Changes:**
- Add `loadPgrubicVersion()` in `core.js` and call it during app startup to populate the version element.
- Refactor `generateShareLink()` to notify on errors instead of throwing, and update tests accordingly.
- Update `index.html` to include a dedicated version `<span>` with the new ID.
